### PR TITLE
actions returns -out as an ambiguous option which result to exit code 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
         # Use continue-on-error to run tests even if test-report is not uploaded
         continue-on-error: true
       - run: |
-          curl -L --out split-test https://github.com/mtsmfm/split-test/releases/download/v1.0.0/split-test-x86_64-unknown-linux-gnu
+          curl -L --output split-test https://github.com/mtsmfm/split-test/releases/download/v1.0.0/split-test-x86_64-unknown-linux-gnu
           chmod +x split-test
       - run: bin/rspec --format progress --format RspecJunitFormatter --out report/rspec-${{ matrix.node_index }}.xml $(./split-test --junit-xml-report-dir report-tmp --node-index ${{ matrix.node_index }} --node-total 3 --tests-glob 'spec/**/*_spec.rb' --debug)
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
We started to get the following exit status when running split test and caused CI to not run. It is possible that GitHub changed `ubuntu-latest` library a bit and caused some update to the curl. It would be great if the team can check it out. 


```sh
Run curl -L --out split-test https://github.com/mtsmfm/split-test/releases/download/v1.0.0/split-test-x86_64-unknown-linux-gnu
[10](https://github.com/yasslab/railsguides.jp_web/actions/runs/3653925624/jobs/6174061904#step:11:11)
curl: option --out: is ambiguous
[11](https://github.com/yasslab/railsguides.jp_web/actions/runs/3653925624/jobs/6174061904#step:11:12)
curl: try 'curl --help' or 'curl --manual' for more information
[12](https://github.com/yasslab/railsguides.jp_web/actions/runs/3653925624/jobs/6174061904#step:11:13)
Error: Process completed with exit code 2.
```

I do not have public repo available to share the fix and where it caused the issue but can share some screenshots. Hope it helps!

<img width="1193" alt="Screen Shot 2022-12-09 at 12 53 19" src="https://user-images.githubusercontent.com/6015450/206620404-93546e95-4617-4ec4-9542-855e795b230e.png">

<img width="1194" alt="Screen Shot 2022-12-09 at 12 53 45" src="https://user-images.githubusercontent.com/6015450/206620472-2164e104-e754-4aaf-912c-28f3af5f38d7.png">

