### PR TITLE
Build arm64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,5 @@ jobs:
       - run: ls -l 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'
       - if: github.ref_type == 'tag'
         run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
             os: ubuntu-latest
             extension: .exe
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: ubuntu-latest
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -29,8 +30,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable
       - run: rustup default stable
-      - run: rustup target add x86_64-unknown-linux-gnu
-      - run: cargo build --release --target=${{ matrix.target }}
+      - run: cargo install cross
+      - run: cross build --release --target=${{ matrix.target }}
       - run: find target
       - if: github.ref_type == 'tag'
         run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - "v*"
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -12,76 +15,22 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-pc-windows-gnu
+          - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            extension: .exe
-          - target: x86_64-apple-darwin
-            os: macos-latest
+          # - target: x86_64-pc-windows-gnu
+          #   os: ubuntu-latest
+          #   extension: .exe
+          # - target: x86_64-apple-darwin
+          #   os: macos-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target=${{ matrix.target }}
-          use-cross: true
-      - uses: actions/upload-artifact@v1
-        with:
-          name: build-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/split-test${{ matrix.extension }}
-
-  create-release:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - run: |
-          echo '${{ steps.create-release.outputs.upload_url }}' > release_upload_url.txt
-      - uses: actions/upload-artifact@v1
-        with:
-          name: create-release
-          path: release_upload_url.txt
-
-  upload-release:
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
-        include:
-          - target: x86_64-pc-windows-gnu
-            extension: .exe
-    needs: [create-release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: create-release
-      - id: upload-url
-        run: |
-          echo "::set-output name=url::$(cat create-release/release_upload_url.txt)"
-      - uses: actions/download-artifact@v1
-        with:
-          name: build-${{ matrix.target }}
-      - run: find .
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.upload-url.outputs.url }}
-          asset_path: build-${{ matrix.target }}/split-test${{ matrix.extension }}
-          asset_name: split-test-${{ matrix.target }}${{ matrix.extension }}
-          asset_content_type: application/octet-stream
+      - uses: actions/checkout@v4
+      - run: rustup update stable
+      - run: rustup default stable
+      - run: rustup target add x86_64-unknown-linux-gnu
+      - run: cargo build --release --target=${{ matrix.target }}
+      - run: find target
+      - if: github.ref_type == 'tag'
+        run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,12 @@ jobs:
       - run: rustup default stable
       - run: cargo install cross
       - run: cross build --release --target=${{ matrix.target }}
-      - run: |
-          cp 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}' \
-             'target/split-test-${{ matrix.target }}${{ matrix.extension }}'
+      - run: cp -v "$target_binary" "$target_asset"
+        env:
+          target_binary: target/${{ matrix.target }}/release/split-test${{ matrix.extension }}
+          target_asset: target/split-test-${{ matrix.target }}${{ matrix.extension }}
       - if: github.ref_type == 'tag'
-        run: gh release upload "$GITHUB_REF_NAME" 'target/split-test-${{ matrix.target }}${{ matrix.extension }}'
+        run: gh release upload "$GITHUB_REF_NAME" "$target_asset"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          target_asset: target/split-test-${{ matrix.target }}${{ matrix.extension }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
       - run: rustup default stable
       - run: cargo install cross
       - run: cross build --release --target=${{ matrix.target }}
-      - run: ls -l 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'
+      - run: |
+          cp 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}' \
+             'target/split-test-${{ matrix.target }}${{ matrix.extension }}'
       - if: github.ref_type == 'tag'
-        run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'
+        run: gh release upload "$GITHUB_REF_NAME" 'target/split-test-${{ matrix.target }}${{ matrix.extension }}'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
           - target: x86_64-pc-windows-gnu
             os: ubuntu-latest
             extension: .exe
-          - target: x86_64-apple-darwin
-            os: ubuntu-latest
+          # - target: x86_64-apple-darwin
+          #   os: ubuntu-latest
           - target: aarch64-apple-darwin
-            os: ubuntu-latest
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,13 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-          # - target: x86_64-pc-windows-gnu
-          #   os: ubuntu-latest
-          #   extension: .exe
-          # - target: x86_64-apple-darwin
-          #   os: macos-latest
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
+            extension: .exe
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -32,6 +34,6 @@ jobs:
       - run: rustup default stable
       - run: cargo install cross
       - run: cross build --release --target=${{ matrix.target }}
-      - run: find target
+      - run: ls -l 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'
       - if: github.ref_type == 'tag'
-        run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test'
+        run: gh release upload "$GITHUB_REF_NAME" 'target/${{ matrix.target }}/release/split-test${{ matrix.extension }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v4
+      - run: rustup update stable
+      - run: rustup default stable
+      - run: cargo test


### PR DESCRIPTION
Hi,

I'd like to run split-test on the self-hosted runners of Linux arm64. This pull request will release both amd64 and arm64 binaries.

In these workflows, some actions are already archived.

- `actions-rs/*` actions are archived. I replaced them with rustup and cargo.
- `actions/upload-release-asset` action is archived. I replaced it with gh command.

Also I could not build a binary for x86_64-apple-darwin due to some errors, so commented it out.

Thanks.
