### PR TITLE
Add exclude glob option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ You'll get:
 
 Please be sure to increment `--node-index` arg.
 
+You can exclude specific test files from being split using the `--tests-exclude-glob` option:
+
+```
+$ split-test --junit-xml-report-dir report --node-index 0 --node-total 2 --tests-glob 'spec/**/*_spec.rb' --tests-exclude-glob 'spec/system/**/*_spec.rb'
+```
+
+This will include all files matching `spec/**/*_spec.rb` but exclude any files matching `spec/system/**/*_spec.rb`. This is useful when you want to run system specs separately from unit tests, as system specs typically take longer and may require different setup.
+
+You can also specify multiple exclude patterns by using the `--tests-exclude-glob` option multiple times:
+
+```
+$ split-test --junit-xml-report-dir report --node-index 0 --node-total 2 --tests-glob 'spec/**/*_spec.rb' --tests-exclude-glob 'spec/system/**/*_spec.rb' --tests-exclude-glob 'spec/integration/**/*_spec.rb'
+```
+
 You can use `--debug` option to make sure how it's grouped:
 
 ```


### PR DESCRIPTION
## Summary

Add support for multiple exclude patterns via `--tests-exclude-glob` option to allow excluding specific test files from the split. This option can be specified multiple times to exclude multiple patterns, matching the behavior of the `--tests-glob` option.

## Motivation

I'm migrating from CircleCI to GitHub Actions and needed exclude pattern support similar to other test splitting tools:

- **Knapsack Pro** supports `KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN` ([docs](https://docs.knapsackpro.com/ruby/reference/#knapsack_pro_test_file_exclude_pattern))
- **split_tests** (Go implementation) supports `--exclude-glob` pattern ([repo](https://github.com/leonid-shevtsov/split_tests))

I prefer `split-test` over the Go alternative, but the missing exclude pattern support was a blocker for my migration.

## Usage Example

```bash
# Single exclude pattern
split-test --tests-glob 'spec/**/*_spec.rb' --tests-exclude-glob 'spec/system/**/*_spec.rb'

# Multiple exclude patterns
split-test --tests-glob 'spec/**/*_spec.rb' \
--tests-exclude-glob 'spec/system/**/*_spec.rb' \
--tests-exclude-glob 'spec/integration/**/*_spec.rb'
```

## Disclosure

⚠️ Full disclosure: This code was generated with AI assistance (Claude Code). I have no prior Rust experience, so I would greatly appreciate a thorough review to ensure the implementation follows Rust best practices and project conventions.