### PR TITLE
Add total test count to debug output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,8 @@ fn main() -> Result<()> {
     }
 
     if log_enabled!(Debug) {
+        debug!("Total test count: {}", test_files.len());
+
         for (i, node) in nodes.iter().enumerate() {
             debug!(
                 "node {}: recorded_total_time: {}",


### PR DESCRIPTION
When --debug option is used, display the total number of test files at the beginning of the debug output to help users understand the overall test distribution across nodes.